### PR TITLE
Resolves #21: mask comand has to be compatible with PicketBox PBE functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     </scm>
 
     <properties>
-        <version.elytron>1.1.0.Beta28</version.elytron>
+        <version.elytron>1.1.0.Beta33</version.elytron>
         <version.commons-cli>1.3.1</version.commons-cli>
         <version.org.jboss.logging>3.2.1.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.0.0.Final</version.org.jboss.logmanager>

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -144,8 +144,8 @@ public interface ElytronToolMessages extends BasicLogger {
     IllegalArgumentException credentialStoreURIParameterNameExpected(String uri);
 
     // mask command
-    @Message(id = Message.NONE, value = "\"mask\" command is used to get MASK- string encrypted using %s in PicketBox compatible way.")
-    String cmdMaskHelpHeader(String algorithm);
+    @Message(id = Message.NONE, value = "\"mask\" command is used to get MASK- string encrypted using PBEWithMD5AndDES in PicketBox compatible way.")
+    String cmdMaskHelpHeader();
 
     @Message(id = Message.NONE, value = "Salt to apply to masked string")
     String cmdMaskSaltDesc();

--- a/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -26,7 +26,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
-import org.wildfly.security.util.Alphabet;
 import org.wildfly.security.util.PasswordBasedEncryptionUtil;
 
 /**
@@ -41,9 +40,6 @@ class MaskCommand extends Command {
      * Command string
      */
     public static final String MASK_COMMAND = "mask";
-
-    static final String DEFAULT_ALGORITHM = "PBEWithMD5AndDES";
-    static final String DEFAULT_PICKETBOX_INITIAL_KEY_MATERIAL = "somearbitrarycrazystringthatdoesnotmatter";
 
     static final String SALT_PARAM = "salt";
     static final String ITERATION_PARAM = "iteration";
@@ -105,9 +101,7 @@ class MaskCommand extends Command {
 
     static String computeMasked(String secret, String salt, int iteration) throws GeneralSecurityException {
         PasswordBasedEncryptionUtil encryptUtil = new PasswordBasedEncryptionUtil.Builder()
-                .alphabet(Alphabet.Base64Alphabet.PICKETBOX_COMPATIBILITY)
-                .keyAlgorithm(DEFAULT_ALGORITHM)
-                .password(DEFAULT_PICKETBOX_INITIAL_KEY_MATERIAL)
+                .picketBoxCompatibility()
                 .salt(salt)
                 .iteration(iteration)
                 .encryptMode()
@@ -123,7 +117,7 @@ class MaskCommand extends Command {
         HelpFormatter help = new HelpFormatter();
         help.setWidth(WIDTH);
         help.printHelp(ElytronToolMessages.msg.cmdHelp(ElytronTool.TOOL_JAR, MASK_COMMAND),
-                ElytronToolMessages.msg.cmdMaskHelpHeader(DEFAULT_ALGORITHM),
+                ElytronToolMessages.msg.cmdMaskHelpHeader(),
                 options,
                 "",
                 true);

--- a/src/test/java/org/wildfly/security/tool/MaskCommandTest.java
+++ b/src/test/java/org/wildfly/security/tool/MaskCommandTest.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+/**
+ * Tests for mask command.
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class MaskCommandTest extends BaseToolTest {
+
+    /**
+     * Basic test to check if output hash is compatible with PicketBox PBE functions.
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void maskCompatibilityCheck() throws Exception {
+
+        ElytronTool tool = new ElytronTool();
+        Command command = tool.findCommand(MaskCommand.MASK_COMMAND);
+
+        final String secret = "super_secret";
+        final String pbGenerated = "088WUKotOwu7VOS8xRj.Rr";  // super_secret;ASDF1234;123
+
+        String[] args = {"--iteration", "123", "--salt", "ASDF1234", "--secret", secret};
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(result));
+        command.execute(args);
+        System.setOut(original);
+        String retVal = result.toString();
+        String retValNoNewLine = retVal.substring(0, retVal.length() - 1);
+        assertEquals("returned command status has to be 0", command.getStatus(), ElytronTool.ElytronToolExitStatus_OK);
+        assertTrue("output has to be the as pre-generated one", ("MASK-" + pbGenerated + ";" + "ASDF1234" + ";" + 123).equals(retValNoNewLine));
+    }
+
+}


### PR DESCRIPTION
With changes related to https://issues.jboss.org/browse/ELY-1013 the mask command has to produce proper output too.