### PR TITLE
[ELY-1056] [JBEAP-9934] CS tool, Without --location parameter a credential store storage file isn't saved (or save as is expected).

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -66,6 +66,7 @@ class CredentialStoreCommand extends Command {
     public static final String HELP_PARAM = "help";
     public static final String PRINT_SUMMARY_PARAM = "summary";
 
+    private static final String CR_STORE_SCHEME = "cr-store";
     private final Options options;
     private CommandLineParser parser = new DefaultParser();
     private CommandLine cmdLine = null;
@@ -142,8 +143,8 @@ class CredentialStoreCommand extends Command {
         boolean createKeyStore = cmdLine.hasOption(CREATE_CREDENTIAL_STORE_PARAM);
         boolean printSummary = cmdLine.hasOption(PRINT_SUMMARY_PARAM);
 
-        if (uri != null) {
-            parse(new URI(uri));
+        if (uri != null && uri.startsWith(CR_STORE_SCHEME + ":")) {
+            parse(new URI(new StringBuilder(uri).insert((CR_STORE_SCHEME + "://").length(), "/").toString()));
         }
         if (location == null) {
             location = storageFile;


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1056
JBEAP: https://issues.jboss.org/browse/JBEAP-9934