### PR TITLE
[ELY-1058] When we set wrong ITERATION value (too big number or string) then we get NumberFormatException.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -165,4 +165,7 @@ public interface ElytronToolMessages extends BasicLogger {
     @Message(id = 6, value = "Salt not specified.")
     MissingArgumentException saltNotSpecified();
 
+    @Message(id = 7, value = "Invalid \"%s\" value. Must be an integer between %d and %d, inclusive")
+    IllegalArgumentException invalidParameterMustBeIntBetween(String parameter, int min, int max);
+
 }

--- a/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -86,9 +86,13 @@ class MaskCommand extends Command {
         if (sIteration != null && !sIteration.isEmpty()) {
             try {
                 iterationCount = Integer.parseInt(sIteration);
+                if (iterationCount < 1) {
+                    setStatus(GENERAL_CONFIGURATION_ERROR);
+                    throw ElytronToolMessages.msg.invalidParameterMustBeIntBetween(ITERATION_PARAM, 1, Integer.MAX_VALUE);
+                }
             } catch (NumberFormatException e) {
                 setStatus(GENERAL_CONFIGURATION_ERROR);
-                throw new Exception(e);
+                throw ElytronToolMessages.msg.invalidParameterMustBeIntBetween(ITERATION_PARAM, 1, Integer.MAX_VALUE);
             }
         }
 


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1058
JBEAP: https://issues.jboss.org/browse/JBEAP-10137

This PR also resolves:
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1059
JBEAP: https://issues.jboss.org/browse/JBEAP-10139