### PR TITLE
[ELY-1054] CS tool, There is possibility add EMPTY alias name and EMPTY secret value to credential store storage file through wildfly-elytron-tool.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -165,9 +165,17 @@ class CredentialStoreCommand extends Command {
                 getProviders(otherProviders));
         if (cmdLine.hasOption(ADD_ALIAS_PARAM)) {
             String alias = cmdLine.getOptionValue(ADD_ALIAS_PARAM);
+            if (alias.length() == 0) {
+                setStatus(GENERAL_CONFIGURATION_ERROR);
+                throw ElytronToolMessages.msg.optionNotSpecified(ADD_ALIAS_PARAM);
+            }
             if (secret == null) {
                 // prompt for secret
                 secret = prompt(false, ElytronToolMessages.msg.secretToStorePrompt(), true, ElytronToolMessages.msg.secretToStorePromptConfirm());
+                if (secret == null) {
+                    setStatus(GENERAL_CONFIGURATION_ERROR);
+                    throw ElytronToolMessages.msg.optionNotSpecified(PASSWORD_CREDENTIAL_VALUE_PARAM);
+                }
             }
             credentialStore.store(alias, createCredential(secret, entryType));
             credentialStore.flush();

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -245,4 +245,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Credential Store has been successfully created")
     String credentialStoreCreated();
+
+    @Message(id = 16, value = "Option \"%s\" is not specified.")
+    MissingArgumentException optionNotSpecified(String option);
 }


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1054
JBEAP: https://issues.jboss.org/browse/JBEAP-10113
Empty secret value should be possible - it was resolved in the CLI already by WFCORE-2455.