### PR TITLE
[ELY-1085] CS tool, Help contains wrong description of "--create" option, there is description with true/false value.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -139,6 +139,10 @@ class CredentialStoreCommand extends Command {
         String entryType = cmdLine.getOptionValue(ENTRY_TYPE_PARAM);
         String otherProviders = cmdLine.getOptionValue(OTHER_PROVIDERS_PARAM);
         boolean createStorage = cmdLine.hasOption(CREATE_CREDENTIAL_STORE_PARAM);
+        if (createStorage && cmdLine.getArgs().length > 0) {
+            setStatus(GENERAL_CONFIGURATION_ERROR);
+            throw ElytronToolMessages.msg.noArgumentOption(CREATE_CREDENTIAL_STORE_PARAM);
+        }
         boolean printSummary = cmdLine.hasOption(PRINT_SUMMARY_PARAM);
         String secret = cmdLine.getOptionValue(PASSWORD_CREDENTIAL_VALUE_PARAM);
 

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -89,7 +89,7 @@ public interface ElytronToolMessages extends BasicLogger {
             "Each provider must be installed through java.security file.")
     String cmdLineOtherProvidersDesc();
 
-    @Message(id = NONE, value = "Create credential store [true/false]")
+    @Message(id = NONE, value = "Create credential store")
     String cmdLineCreateCredentialStoreDesc();
 
     @Message(id = NONE, value = "Credential store type")
@@ -254,4 +254,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = 16, value = "Option \"%s\" is not specified.")
     MissingArgumentException optionNotSpecified(String option);
+
+    @Message(id = 17, value = "Option \"%s\" does not expect any arguments.")
+    MissingArgumentException noArgumentOption(String option);
 }


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1085
JBEAP: https://issues.jboss.org/browse/JBEAP-10386

"--create" option is only a flag and doesn't expect any arguments.