### PR TITLE
[ELY-1056] (reopen) CS tool, Without --location parameter a credential store storage file isn't saved (or save as is expected).

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -132,6 +132,10 @@ class CredentialStoreCommand extends Command {
         }
 
         String location = cmdLine.getOptionValue(STORE_LOCATION_PARAM);
+        if (location == null) {
+            setStatus(GENERAL_CONFIGURATION_ERROR);
+            throw ElytronToolMessages.msg.optionNotSpecified(STORE_LOCATION_PARAM);
+        }
         String csPassword = cmdLine.getOptionValue(CREDENTIAL_STORE_PASSWORD_PARAM);
         String salt = cmdLine.getOptionValue(SALT_PARAM);
         String csType = cmdLine.getOptionValue(CREDENTIAL_STORE_TYPE_PARAM, KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE);


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1056 (reopen)
JBEAP: https://issues.jboss.org/browse/JBEAP-9934 (reopen)

Making the "location" option required.