### PR TITLE
[ELY-1128][JBEAP-10696]: Show an interactive prompt when keystore-password is missing using vault command

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -254,4 +254,10 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = 16, value = "Option \"%s\" is not specified.")
     MissingArgumentException optionNotSpecified(String option);
+
+    @Message(id = NONE, value = "Vault password: ")
+    String vaultPasswordPrompt();
+
+    @Message(id = NONE, value = "Confirm vault password: ")
+    String vaultPasswordPromptConfirm();
 }

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -163,7 +163,7 @@ public class VaultCommand extends Command {
             // single Vault conversion
             // default values are from VaultTool
             String keystoreURL = cmdLine.getOptionValue(KEYSTORE_PARAM, "vault.keystore");
-            String keystorePassword = cmdLine.getOptionValue(KEYSTORE_PASSWORD_PARAM, "");
+            String keystorePassword = cmdLine.getOptionValue(KEYSTORE_PASSWORD_PARAM);
             String encryptionDirectory = cmdLine.getOptionValue(ENC_DIR_PARAM, "vault");
             String salt = cmdLine.getOptionValue(SALT_PARAM, "12345678");
             int iterationCount = Integer.parseInt(cmdLine.getOptionValue(ITERATION_PARAM, "23"));
@@ -174,6 +174,10 @@ public class VaultCommand extends Command {
                 location = convertedStoreName(encryptionDirectory);
             }
             Map<String, String> implProps = CredentialStoreCommand.parseCredentialStoreProperties(cmdLine.getOptionValue(CredentialStoreCommand.IMPLEMENTATION_PROPERTIES_PARAM));
+
+            if (keystorePassword == null) {
+                keystorePassword = prompt(false, ElytronToolMessages.msg.vaultPasswordPrompt(), true, ElytronToolMessages.msg.vaultPasswordPromptConfirm());
+            }
 
             convert(keystoreURL, keystorePassword, encryptionDirectory, salt, iterationCount, vaultSecretKeyAlias,
                     location, implProps);


### PR DESCRIPTION
If user omits the --keystore-password argument in vault command, an interactive prompt is shown to get a valid value. 

Jira issues:
https://issues.jboss.org/browse/ELY-1128
https://issues.jboss.org/browse/JBEAP-10696