### PR TITLE
[ELY-1124] WildFly Elytron Tool, Vault commands with wrongly filled path to vaults should fail.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -269,4 +269,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Confirm vault password: ")
     String vaultPasswordPromptConfirm();
+
+    @Message(id = 19, value = "The value \"%s\" is not a valid path to directory.")
+    IllegalArgumentException pathNotValid(String path);
 }

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
@@ -234,7 +236,12 @@ public class VaultCommand extends Command {
             throws Exception {
 
         final HashMap<String, String> vaultInitialOptions = new HashMap<>();
-        vaultInitialOptions.put("location", encryptionDirectory);
+        if (Files.exists(Paths.get(encryptionDirectory))) {
+            vaultInitialOptions.put("location", encryptionDirectory);
+        } else
+        {
+            throw ElytronToolMessages.msg.pathNotValid(encryptionDirectory);
+        }
         vaultInitialOptions.put("create", Boolean.FALSE.toString());
 
         CredentialStore vaultCredentialStore = getInstance(VaultCredentialStore.VAULT_CREDENTIAL_STORE);


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1124
JBEAP: https://issues.jboss.org/browse/JBEAP-10685