### PR TITLE
[ELY-1125] WildFly Elytron Tool, Omitting --location for Vault command leads to wrong credential store storage file in tool output and in summary output.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -225,7 +225,7 @@ public class VaultCommand extends Command {
     }
 
     private String convertedStoreName(String encryptionDirectory) {
-        return encryptionDirectory + (encryptionDirectory.isEmpty() ? "" : File.separator) + "converted-vault.cr-store";
+        return encryptionDirectory + (encryptionDirectory.isEmpty() || encryptionDirectory.endsWith(File.separator) ? "" : File.separator) + "converted-vault.cr-store";
     }
 
     private void convert(String keyStoreURL, String vaultPassword, String encryptionDirectory,


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1125
JBEAP: https://issues.jboss.org/browse/JBEAP-10692

Issue: Summary output must not contain double slash in location