### PR TITLE
[ELY-1091][JBEAP-10411]: Fixed inconsistent credential store name found in the summary report

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -265,7 +265,7 @@ class CredentialStoreCommand extends Command {
             } else if (cmdLine.hasOption(ALIASES_PARAM)) {
                 com.append("/subsystem=elytron/credential-store=test:read-children-names(child-type=alias)");
             } else if (cmdLine.hasOption(CHECK_ALIAS_PARAM)) {
-                com.append("ls /subsystem=elytron/credential-store=test1/alias=");
+                com.append("ls /subsystem=elytron/credential-store=test/alias=");
                 com.append(cmdLine.getOptionValue(CHECK_ALIAS_PARAM));
             } else if ( cmdLine.hasOption(CREATE_CREDENTIAL_STORE_PARAM) ){
                 getCreateSummary(implProps, com, password);


### PR DESCRIPTION
Issue was re-opened because there was an inconsistence between credential store names used in the summary report.

Jira issues are:
https://issues.jboss.org/browse/ELY-1091
https://issues.jboss.org/browse/JBEAP-10411