### PR TITLE
ELY-1162: Show an interactive prompt when secret is missing using mask command

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -269,4 +269,10 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Confirm vault password: ")
     String vaultPasswordPromptConfirm();
+
+    @Message(id = NONE, value = "Mask secret: ")
+    String maskSecretPrompt();
+
+    @Message(id = NONE, value = "Confirm mask secret: ")
+    String maskSecretPromptConfirm();
 }

--- a/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -96,8 +96,7 @@ class MaskCommand extends Command {
 
         String secret = cmdLine.getOptionValue(SECRET_PARAM);
         if (secret == null) {
-            setStatus(GENERAL_CONFIGURATION_ERROR);
-            throw ElytronToolMessages.msg.secretNotSpecified();
+            secret = prompt(false, ElytronToolMessages.msg.maskSecretPrompt(), true, ElytronToolMessages.msg.maskSecretPromptConfirm());
         }
 
         final String masked = computeMasked(secret, salt, iterationCount);


### PR DESCRIPTION
If user omits the --secret argument in mask command, an interactive prompt is shown to get a valid value.

Jira issues:
https://issues.jboss.org/browse/ELY-1162
https://issues.jboss.org/browse/JBEAP-10959