### PR TITLE
[ELY-1164] Wildfly Elytron Tool, credential-store command doesn't support redirection (<, <<) when multiple options are missing which show prompts.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -164,6 +164,10 @@ class CredentialStoreCommand extends Command {
         if (csPassword == null) {
             // prompt for password
             csPassword = prompt(false, ElytronToolMessages.msg.credentialStorePasswordPrompt(), true, ElytronToolMessages.msg.credentialStorePasswordPromptConfirm());
+            if (csPassword == null) {
+                setStatus(GENERAL_CONFIGURATION_ERROR);
+                throw ElytronToolMessages.msg.optionNotSpecified(CREDENTIAL_STORE_PASSWORD_PARAM);
+            }
         }
         if (csPassword != null) {
             credentialSourceProtectionParameter = new CredentialStore.CredentialSourceProtectionParameter(


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1164
JBEAP: https://issues.jboss.org/browse/JBEAP-10966
