### PR TITLE
[ELY-1086](Reopen) CS tool, Command without any option must show help rather then error message about required options.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronTool.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronTool.java
@@ -80,7 +80,11 @@ public class ElytronTool {
                     System.exit(command.getStatus());
                 }
             } else if ("--help".equals(args[0]) || "-h".equals(args[0]) || (command != null && newArgs.length == 0)) {
-                tool.generalHelp();
+                if (command != null) {
+                    command.help();
+                } else {
+                    tool.generalHelp();
+                }
             } else {
                 System.err.println(ElytronToolMessages.msg.commandOrAliasNotFound(args[0]));
                 System.exit(ElytronToolExitStatus_unrecognizedCommand);


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1086
JBEAP: https://issues.jboss.org/browse/JBEAP-10395

Implementing command specific help message.