### PR TITLE
[ELY-1131] WildFly Elytron Tool, For vault command bulk-convert is missing validation for parsed values from description file

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -281,4 +281,19 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Confirm mask secret: ")
     String maskSecretPromptConfirm();
+
+    @Message(id = 20, value = "Alias was not defined.")
+    MissingArgumentException undefinedAlias();
+
+    @Message(id = 21, value = "Location of the output file was not defined.")
+    MissingArgumentException undefinedOutputLocation();
+
+    @Message(id = 22, value = "Encryption directory was not defined.")
+    MissingArgumentException undefinedEncryptionDirectory();
+
+    @Message(id = 23, value = "Vault password was not defined")
+    MissingArgumentException undefinedVaultPassword();
+
+    @Message(id = 24, value = "Cannot parse conversion descriptor file \"%s\". No keystore specified.")
+    IOException undefinedKeystore(String file);
 }

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -153,6 +153,11 @@ public class VaultCommand extends Command {
 
             // bulk conversion
             List<Descriptor> descriptors = parseDescriptorFile(bulkConversionDescriptor);
+
+            if (descriptors.size() == 0) {
+                throw ElytronToolMessages.msg.undefinedKeystore(bulkConversionDescriptor);
+            }
+
             for(Descriptor d: descriptors) {
                 try {
                     convert(d.keyStoreURL, d.vaultPassword, d.encryptionDirectory, d.salt, d.iterationCount, d.secretKeyAlias, d.outputFile, d.implProps);
@@ -229,11 +234,28 @@ public class VaultCommand extends Command {
             throws Exception {
 
         final HashMap<String, String> vaultInitialOptions = new HashMap<>();
+
+        if (encryptionDirectory == null || "".equals(encryptionDirectory)) {
+            throw ElytronToolMessages.msg.undefinedEncryptionDirectory();
+        }
+
         if (Files.exists(Paths.get(encryptionDirectory))) {
             vaultInitialOptions.put("location", encryptionDirectory);
         } else
         {
             throw ElytronToolMessages.msg.pathNotValid(encryptionDirectory);
+        }
+
+        if (secretKeyAlias == null || "".equals(secretKeyAlias)) {
+            throw ElytronToolMessages.msg.undefinedAlias();
+        }
+
+        if (outputFile == null || "".equals(outputFile)) {
+            throw ElytronToolMessages.msg.undefinedOutputLocation();
+        }
+
+        if (vaultPassword == null || "".equals(vaultPassword)) {
+            throw ElytronToolMessages.msg.undefinedVaultPassword();
         }
 
         CredentialStore vaultCredentialStore = getInstance(VaultCredentialStore.VAULT_CREDENTIAL_STORE);

--- a/src/test/java/org/wildfly/security/tool/VaultCommandTest.java
+++ b/src/test/java/org/wildfly/security/tool/VaultCommandTest.java
@@ -93,7 +93,7 @@ public class VaultCommandTest extends AbstractCommandTest {
 
     /**
      * Bulk vault conversion test with wrong option
-     * @throws Exception when something ges wrong
+     * @throws Exception when something goes wrong
      */
     @Test
     public void bulkConversionWrongOption() {
@@ -118,5 +118,90 @@ public class VaultCommandTest extends AbstractCommandTest {
         Assert.assertTrue(output.contains("Option \"enc-dir\" specified more than once. Only the first occurrence will be used."));
         Assert.assertTrue(output.contains("Option \"keystore\" specified more than once. Only the first occurrence will be used."));
         Assert.assertFalse(output.contains("Option \"salt\" specified more than once. Only the first occurrence will be used"));
+    }
+
+    /**
+     * Bulk vault conversion missing the alias option
+     */
+    @Test
+    public void bulkConversionMissingAliasOption() {
+        String[] args = {"--bulk-convert", "target/test-classes/bulk-vault-conversion-no-alias"};
+        boolean testFailed = true;
+        try {
+            executeCommandAndCheckStatus(args);
+        } catch (Exception e) {
+            // Exception is wrapped inside ELYTOOL00012
+            Assert.assertTrue(e.getCause().getCause().getMessage().contains("ELYTOOL00020"));
+        }
+
+        Assert.assertFalse("Test was supposed to throw exception!", testFailed);
+    }
+
+    /**
+     * Bulk vault conversion missing the location option
+     */
+    @Test
+    public void bulkConversionMissingLocationOption() {
+        String[] args = {"--bulk-convert", "target/test-classes/bulk-vault-conversion-no-location"};
+        boolean testFailed = true;
+        try {
+            executeCommandAndCheckStatus(args);
+        } catch (Exception e) {
+            // Exception is wrapped inside ELYTOOL00012
+            Assert.assertTrue(e.getCause().getCause().getMessage().contains("ELYTOOL00021"));
+        }
+
+        Assert.assertFalse("Test was supposed to throw exception!", testFailed);
+    }
+
+    /**
+     * Bulk vault conversion missing the enc-dir option
+     */
+    @Test
+    public void bulkConversionMissingEncryptionDirOption() {
+        String[] args = {"--bulk-convert", "target/test-classes/bulk-vault-conversion-no-enc-dir"};
+        boolean testFailed = true;
+        try {
+            executeCommandAndCheckStatus(args);
+        } catch (Exception e) {
+            // Exception is wrapped inside ELYTOOL00012
+            Assert.assertTrue(e.getCause().getCause().getMessage().contains("ELYTOOL00022"));
+        }
+
+        Assert.assertFalse("Test was supposed to throw exception!", testFailed);
+    }
+
+    /**
+     * Bulk vault conversion missing the keystore-password option
+     */
+    @Test
+    public void bulkConversionMissingKeystorePasswordOption() {
+        String[] args = {"--bulk-convert", "target/test-classes/bulk-vault-conversion-no-keystore-password"};
+        boolean testFailed = true;
+        try {
+            executeCommandAndCheckStatus(args);
+        } catch (Exception e) {
+            // Exception is wrapped inside ELYTOOL00012
+            Assert.assertTrue(e.getCause().getCause().getMessage().contains("ELYTOOL00023"));
+        }
+
+        Assert.assertFalse("Test was supposed to throw exception!", testFailed);
+    }
+
+    /**
+     * Bulk vault conversion missing the keystore option
+     */
+    @Test
+    public void bulkConversionMissingKeystoreOption() {
+        String[] args = {"--bulk-convert", "target/test-classes/bulk-vault-conversion-no-keystore-url"};
+        boolean testFailed = true;
+        try {
+            executeCommandAndCheckStatus(args);
+        } catch (Exception e) {
+            testFailed = false;
+            Assert.assertTrue(e.getCause().getMessage().contains("ELYTOOL00024"));
+        }
+
+        Assert.assertFalse("Test was supposed to throw exception!", testFailed);
     }
 }

--- a/src/test/resources/bulk-vault-conversion-no-alias
+++ b/src/test/resources/bulk-vault-conversion-no-alias
@@ -1,0 +1,8 @@
+# Bulk conversion descriptor
+keystore:server.store
+keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
+enc-dir:target/v1-cs-more.store
+salt:12345678
+iteration:34
+location:target/converted.jceks
+#alias:jboss

--- a/src/test/resources/bulk-vault-conversion-no-enc-dir
+++ b/src/test/resources/bulk-vault-conversion-no-enc-dir
@@ -1,0 +1,8 @@
+# Bulk conversion descriptor
+keystore:server.store
+keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
+#enc-dir:target/v1-cs-more.store
+salt:12345678
+iteration:34
+location:target/converted.jceks
+alias:jboss

--- a/src/test/resources/bulk-vault-conversion-no-keystore-password
+++ b/src/test/resources/bulk-vault-conversion-no-keystore-password
@@ -1,0 +1,8 @@
+# Bulk conversion descriptor
+keystore:server.store
+#keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
+enc-dir:target/v1-cs-more.store
+salt:12345678
+iteration:34
+location:target/converted.jceks
+alias:jboss

--- a/src/test/resources/bulk-vault-conversion-no-keystore-url
+++ b/src/test/resources/bulk-vault-conversion-no-keystore-url
@@ -1,0 +1,8 @@
+# Bulk conversion descriptor
+#keystore:server.store
+keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
+enc-dir:target/v1-cs-more.store
+salt:12345678
+iteration:34
+location:target/converted.jceks
+alias:jboss

--- a/src/test/resources/bulk-vault-conversion-no-location
+++ b/src/test/resources/bulk-vault-conversion-no-location
@@ -1,0 +1,8 @@
+# Bulk conversion descriptor
+keystore:server.store
+keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
+enc-dir:target/v1-cs-more.store
+salt:12345678
+iteration:34
+#location:target/converted.jceks
+alias:jboss


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ELY-1131