### PR TITLE
[ELY-1205] Wildfly Elytron Tool error output would contain error message rather than stacktrace.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/Command.java
+++ b/src/main/java/org/wildfly/security/tool/Command.java
@@ -48,6 +48,8 @@ public abstract class Command {
 
     private List<String> redirectionValues;
 
+    private boolean enableDebug;
+
     public abstract void execute(String[] args) throws Exception;
 
     /**
@@ -189,5 +191,19 @@ public abstract class Command {
         for (Option option : duplicatesSet) {
             System.out.println(ElytronToolMessages.msg.duplicateOptionSpecified(option.getLongOpt()));
         }
+    }
+
+    /**
+     * Get the command debug option
+     */
+    public boolean isEnableDebug() {
+        return enableDebug;
+    }
+
+    /**
+     * Set the command debug option
+     */
+    public void setEnableDebug(boolean enableDebug) {
+        this.enableDebug = enableDebug;
     }
 }

--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -68,6 +68,7 @@ class CredentialStoreCommand extends Command {
     public static final String PRINT_SUMMARY_PARAM = "summary";
     public static final String ENTRY_TYPE_PARAM = "entry-type";
     public static final String OTHER_PROVIDERS_PARAM = "other-providers";
+    public static final String DEBUG_PARAM = "debug";
 
     private final Options options;
     private CommandLineParser parser = new DefaultParser();
@@ -113,12 +114,14 @@ class CredentialStoreCommand extends Command {
         r.setArgName("alias");
         Option v = new Option("v", ALIASES_PARAM, false, ElytronToolMessages.msg.cmdLineAliasesDesc());
         Option h = new Option("h", HELP_PARAM, false, ElytronToolMessages.msg.cmdLineHelp());
+        Option d = new Option("d", DEBUG_PARAM, false, ElytronToolMessages.msg.cmdLineDebug());
         og.addOption(a);
         og.addOption(e);
         og.addOption(r);
         og.addOption(v);
         options.addOptionGroup(og);
         options.addOption(h);
+        options.addOption(d);
     }
 
     @Override
@@ -132,6 +135,7 @@ class CredentialStoreCommand extends Command {
         }
 
         printDuplicatesWarning(cmdLine);
+        setEnableDebug(cmdLine.hasOption(DEBUG_PARAM));
 
         String location = cmdLine.getOptionValue(STORE_LOCATION_PARAM);
         if (location == null) {

--- a/src/main/java/org/wildfly/security/tool/ElytronTool.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronTool.java
@@ -75,8 +75,18 @@ public class ElytronTool {
                     command.execute(newArgs);
                     System.exit(command.getStatus());
                 } catch (Exception e) {
-                    System.err.println(ElytronToolMessages.msg.commandExecuteException());
-                    e.printStackTrace(System.err);
+                    if (command.isEnableDebug()) {
+                        System.err.println(ElytronToolMessages.msg.commandExecuteException());
+                        e.printStackTrace(System.err);
+                    } else {
+                        if (e.getLocalizedMessage() != null && e.getLocalizedMessage().startsWith("ELYTOOL"))
+                        {
+                            System.err.println(ElytronToolMessages.msg.commandExecuteException());
+                            System.err.println(e.getLocalizedMessage());
+                        } else {
+                            System.err.println(ElytronToolMessages.msg.commandExecuteExceptionNoDebug());
+                        }
+                    }
                     System.exit(command.getStatus());
                 }
             } else if ("--help".equals(args[0]) || "-h".equals(args[0]) || (command != null && newArgs.length == 0)) {

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -281,4 +281,10 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Confirm mask secret: ")
     String maskSecretPromptConfirm();
+
+    @Message(id = NONE, value = "Print stack trace when error occurs.")
+    String cmdLineDebug();
+
+    @Message(id = NONE, value = "Exception encountered executing the command. Use option \"--debug\" for complete exception stack trace.")
+    String commandExecuteExceptionNoDebug();
 }

--- a/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -44,6 +44,7 @@ class MaskCommand extends Command {
     static final String ITERATION_PARAM = "iteration";
     static final String SECRET_PARAM = "secret";
     static final String HELP_PARAM = "help";
+    static final String DEBUG_PARAM = "debug";
 
     private final Options options;
     private CommandLineParser parser = new DefaultParser();
@@ -54,12 +55,14 @@ class MaskCommand extends Command {
         Option iteration = new Option("i", ITERATION_PARAM, true, ElytronToolMessages.msg.cmdMaskIterationCountDesc());
         Option h = new Option("h", HELP_PARAM, false, ElytronToolMessages.msg.cmdLineHelp());
         Option x = new Option("x", SECRET_PARAM, true, ElytronToolMessages.msg.cmdMaskSecretDesc());
+        Option d = new Option("d", DEBUG_PARAM, false, ElytronToolMessages.msg.cmdLineDebug());
         x.setArgName("to encrypt");
         options = new Options();
         options.addOption(x);
         options.addOption(h);
         options.addOption(salt);
         options.addOption(iteration);
+        options.addOption(d);
     }
 
     @Override
@@ -73,6 +76,7 @@ class MaskCommand extends Command {
         }
 
         printDuplicatesWarning(cmdLine);
+        setEnableDebug(cmdLine.hasOption(DEBUG_PARAM));
 
         String salt = cmdLine.getOptionValue(SALT_PARAM);
         if (salt == null) {

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -83,6 +83,7 @@ public class VaultCommand extends Command {
     public static final String ITERATION_PARAM = "iteration";
     public static final String ALIAS_PARAM = "alias";
     public static final String HELP_PARAM = "help";
+    public static final String DEBUG_PARAM = "debug";
 
     private static final class Descriptor {
         String keyStoreURL;
@@ -129,8 +130,10 @@ public class VaultCommand extends Command {
         Option b = new Option("b", BULK_CONVERT_PARAM, true, ElytronToolMessages.msg.cliCommandBulkVaultCredentialStoreConversion());
         b.setArgName("description file");
         Option h = new Option("h", HELP_PARAM, false, ElytronToolMessages.msg.cmdLineHelp());
+        Option d = new Option("d", DEBUG_PARAM, false, ElytronToolMessages.msg.cmdLineDebug());
         options.addOption(b);
         options.addOption(h);
+        options.addOption(d);
 
     }
 
@@ -146,6 +149,7 @@ public class VaultCommand extends Command {
         boolean printSummary = cmdLine.hasOption(PRINT_SUMMARY_PARAM);
 
         printDuplicatesWarning(cmdLine);
+        setEnableDebug(cmdLine.hasOption(DEBUG_PARAM));
 
         String bulkConversionDescriptor = cmdLine.getOptionValue(BULK_CONVERT_PARAM);
         if (bulkConversionDescriptor != null && !bulkConversionDescriptor.isEmpty()) {


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1205
JBEAP: https://issues.jboss.org/browse/JBEAP-11163

Adding option --debug which enables print stack trace when error occurs.