### PR TITLE
ELY-1091: Fix print summary because aliases are not longer resources

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -276,7 +276,6 @@ class CredentialStoreCommand extends Command {
 
 
         if (printSummary) {
-
             StringBuilder com = new StringBuilder();
             String password = csPassword == null ? "" : csPassword;
 
@@ -285,28 +284,25 @@ class CredentialStoreCommand extends Command {
                     password = MaskCommand.computeMasked(csPassword, salt, iterationCount);
                 }
 
-                if (createStorage) {
+                if ( implProps.get("create") != null && implProps.get("create").equals("true") ) {
                     getCreateSummary(implProps, com, password);
                     com.append("\n");
                 }
 
-                com.append("/subsystem=elytron/credential-store=test/alias=");
+                com.append("/subsystem=elytron/credential-store=test:add-alias(alias=");
                 com.append(cmdLine.getOptionValue(ADD_ALIAS_PARAM));
-                com.append(":add(secret-value=\"");
+                com.append(",secret-value=\"");
                 com.append(secret);
                 com.append("\")");
 
             } else if (cmdLine.hasOption(REMOVE_ALIAS_PARAM)) {
 
-                com.append("/subsystem=elytron/credential-store=test/alias=");
+                com.append("/subsystem=elytron/credential-store=test:remove-alias(alias=");
                 com.append(cmdLine.getOptionValue(REMOVE_ALIAS_PARAM));
-                com.append(":remove()");
+                com.append(")");
 
-            } else if (cmdLine.hasOption(ALIASES_PARAM)) {
-                com.append("/subsystem=elytron/credential-store=test:read-children-names(child-type=alias)");
-            } else if (cmdLine.hasOption(CHECK_ALIAS_PARAM)) {
-                com.append("ls /subsystem=elytron/credential-store=test/alias=");
-                com.append(cmdLine.getOptionValue(CHECK_ALIAS_PARAM));
+            } else if (cmdLine.hasOption(ALIASES_PARAM) || cmdLine.hasOption(CHECK_ALIAS_PARAM) ) {
+                com.append("/subsystem=elytron/credential-store=test:read-aliases()");
             } else if ( cmdLine.hasOption(CREATE_CREDENTIAL_STORE_PARAM) ){
                 getCreateSummary(implProps, com, password);
             }
@@ -438,15 +434,23 @@ class CredentialStoreCommand extends Command {
     }
 
     static void getCreateSummary(Map<String, String> implProps, StringBuilder com, String password) {
-        com.append("/subsystem=elytron/credential-store=cs:add(");
+        com.append("/subsystem=elytron/credential-store=test:add(");
         com.append("relative-to=jboss.server.data.dir,");
-        com.append("create=true,");
         if (implProps != null && !implProps.isEmpty()) {
+            if (implProps.get("create") != null) {
+                com.append("create=")
+                        .append(implProps.get("create"))
+                        .append(",");
+            }
             if (implProps.get("modifiable") != null) {
-                com.append("modifiable=" + implProps.get("modifiable") + ",");
+                com.append("modifiable=")
+                        .append(implProps.get("modifiable"))
+                        .append(",");
             }
             if (implProps.get("location") != null) {
-                com.append("location=\"" + implProps.get("location") + "\",");
+                com.append("location=\"")
+                        .append(implProps.get("location"))
+                        .append("\",");
             }
             String props = formatPropertiesForCli(implProps);
             if (!props.isEmpty()) {

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -164,10 +164,10 @@ public class VaultCommand extends Command {
 
             for(Descriptor d: descriptors) {
                 try {
-                    convert(d.keyStoreURL, d.vaultPassword, d.encryptionDirectory, d.salt, d.iterationCount, d.secretKeyAlias, d.outputFile, d.implProps);
+                    final HashMap<String, String> convertedOptions = convert(d.keyStoreURL, d.vaultPassword, d.encryptionDirectory, d.salt, d.iterationCount, d.secretKeyAlias, d.outputFile, d.implProps);
                     System.out.println(ElytronToolMessages.msg.vaultConvertedToCS(d.encryptionDirectory, d.keyStoreURL, d.outputFile));
                     if (printSummary) {
-                        printSummary(d.vaultPassword, d.salt, d.iterationCount, d.implProps);
+                        printSummary(d.vaultPassword, d.salt, d.iterationCount, convertedOptions);
                     }
                 } catch (Throwable e) {
                     throw ElytronToolMessages.msg.bulkConversionProblem(d.encryptionDirectory, d.keyStoreURL, e);
@@ -195,12 +195,12 @@ public class VaultCommand extends Command {
                 keystorePassword = prompt(false, ElytronToolMessages.msg.vaultPasswordPrompt(), true, ElytronToolMessages.msg.vaultPasswordPromptConfirm());
             }
 
-            convert(keystoreURL, keystorePassword, encryptionDirectory, salt, iterationCount, vaultSecretKeyAlias,
+            final HashMap<String, String> convertedOptions = convert(keystoreURL, keystorePassword, encryptionDirectory, salt, iterationCount, vaultSecretKeyAlias,
                     location, implProps);
             System.out.println(ElytronToolMessages.msg.vaultConvertedToCS(encryptionDirectory, keystoreURL, location));
             setStatus(ElytronTool.ElytronToolExitStatus_OK);
             if (printSummary) {
-                printSummary(keystorePassword, salt, iterationCount, implProps);
+                printSummary(keystorePassword, salt, iterationCount, convertedOptions);
             }
         }
 
@@ -232,7 +232,7 @@ public class VaultCommand extends Command {
         return encryptionDirectory + (encryptionDirectory.isEmpty() || encryptionDirectory.endsWith(File.separator) ? "" : File.separator) + "converted-vault.cr-store";
     }
 
-    private void convert(String keyStoreURL, String vaultPassword, String encryptionDirectory,
+    private HashMap<String, String> convert(String keyStoreURL, String vaultPassword, String encryptionDirectory,
                          String salt, int iterationCount, String secretKeyAlias,
                          String outputFile, Map<String, String> csAttributes)
             throws Exception {
@@ -282,6 +282,8 @@ public class VaultCommand extends Command {
             convertedCredentialStore.store(alias, credential);
         }
         convertedCredentialStore.flush();
+
+        return convertedOptions;
     }
 
     private List<Descriptor> parseDescriptorFile(String descriptorFileLocation) throws IOException {


### PR DESCRIPTION
Aliases were removed as resources so print summary must be adapted according. to that change.

Jira issues:
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1091
JBEAP: https://issues.jboss.org/browse/JBEAP-10411

