### PR TITLE
[ELY-1231] WildFly Elytron Tool, Vault commands with --enc-dir option leads to directory which doesn't contain VAULT.dat should fail.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -274,8 +274,8 @@ public interface ElytronToolMessages extends BasicLogger {
     @Message(id = NONE, value = "Confirm vault password: ")
     String vaultPasswordPromptConfirm();
 
-    @Message(id = 19, value = "The value \"%s\" is not a valid path to directory.")
-    IllegalArgumentException pathNotValid(String path);
+    @Message(id = 19, value = "Encryption directory \"%s\" does not contain \"VAULT.dat\" file.")
+    IllegalArgumentException vaultFileNotFound(String path);
 
     @Message(id = NONE, value = "Mask secret: ")
     String maskSecretPrompt();

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -25,8 +25,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.spec.AlgorithmParameterSpec;
@@ -243,11 +241,12 @@ public class VaultCommand extends Command {
             throw ElytronToolMessages.msg.undefinedEncryptionDirectory();
         }
 
-        if (Files.exists(Paths.get(encryptionDirectory))) {
+        final File locationFile = new File(encryptionDirectory, "VAULT.dat");
+        if (locationFile.exists()) {
             vaultInitialOptions.put("location", encryptionDirectory);
         } else
         {
-            throw ElytronToolMessages.msg.pathNotValid(encryptionDirectory);
+            throw ElytronToolMessages.msg.vaultFileNotFound(encryptionDirectory);
         }
 
         if (secretKeyAlias == null || "".equals(secretKeyAlias)) {

--- a/src/test/resources/bulk-vault-conversion-no-alias
+++ b/src/test/resources/bulk-vault-conversion-no-alias
@@ -1,7 +1,7 @@
 # Bulk conversion descriptor
 keystore:server.store
 keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
-enc-dir:target/v1-cs-more.store
+enc-dir:target/test-classes/vault-v1/vault_data/
 salt:12345678
 iteration:34
 location:target/converted.jceks

--- a/src/test/resources/bulk-vault-conversion-no-enc-dir
+++ b/src/test/resources/bulk-vault-conversion-no-enc-dir
@@ -1,7 +1,7 @@
 # Bulk conversion descriptor
 keystore:server.store
 keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
-#enc-dir:target/v1-cs-more.store
+#enc-dir:target/test-classes/vault-v1/vault_data/
 salt:12345678
 iteration:34
 location:target/converted.jceks

--- a/src/test/resources/bulk-vault-conversion-no-keystore-password
+++ b/src/test/resources/bulk-vault-conversion-no-keystore-password
@@ -1,7 +1,7 @@
 # Bulk conversion descriptor
 keystore:server.store
 #keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
-enc-dir:target/v1-cs-more.store
+enc-dir:target/test-classes/vault-v1/vault_data/
 salt:12345678
 iteration:34
 location:target/converted.jceks

--- a/src/test/resources/bulk-vault-conversion-no-keystore-url
+++ b/src/test/resources/bulk-vault-conversion-no-keystore-url
@@ -1,7 +1,7 @@
 # Bulk conversion descriptor
 #keystore:server.store
 keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
-enc-dir:target/v1-cs-more.store
+enc-dir:target/test-classes/vault-v1/vault_data/
 salt:12345678
 iteration:34
 location:target/converted.jceks

--- a/src/test/resources/bulk-vault-conversion-no-location
+++ b/src/test/resources/bulk-vault-conversion-no-location
@@ -1,7 +1,7 @@
 # Bulk conversion descriptor
 keystore:server.store
 keystore-password:MASK-2hKo56F1a3jYGnJwhPmiF5
-enc-dir:target/v1-cs-more.store
+enc-dir:target/test-classes/vault-v1/vault_data/
 salt:12345678
 iteration:34
 #location:target/converted.jceks


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1231
JBEAP: https://issues.jboss.org/browse/JBEAP-11392