### PR TITLE
[ELY-1228] Wildfly Elytron Tool, help output contains "java -jar wildfly-elytron-tool.jar" instead of "wildfly-elytron.sh/bat/ps1" script name.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/Command.java
+++ b/src/main/java/org/wildfly/security/tool/Command.java
@@ -50,6 +50,11 @@ public abstract class Command {
 
     private boolean enableDebug;
 
+    /**
+     * Command used to execute the tool.
+     */
+    private String toolCommand = "java -jar wildfly-elytron-tool.jar";
+
     public abstract void execute(String[] args) throws Exception;
 
     /**
@@ -205,5 +210,19 @@ public abstract class Command {
      */
     public void setEnableDebug(boolean enableDebug) {
         this.enableDebug = enableDebug;
+    }
+
+    /**
+     * Get tool command
+     */
+    public String getToolCommand() {
+        return toolCommand;
+    }
+
+    /**
+     * Set tool command
+     */
+    public void setToolCommand(String toolCommand) {
+        this.toolCommand = toolCommand;
     }
 }

--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -382,7 +382,7 @@ class CredentialStoreCommand extends Command {
     public void help() {
         HelpFormatter help = new HelpFormatter();
         help.setWidth(WIDTH);
-        help.printHelp(ElytronToolMessages.msg.cmdHelp(ElytronTool.TOOL_JAR, CREDENTIAL_STORE_COMMAND),
+        help.printHelp(ElytronToolMessages.msg.cmdHelp(getToolCommand(), CREDENTIAL_STORE_COMMAND),
                 ElytronToolMessages.msg.cmdLineCredentialStoreHelpHeader(),
                 options,
                 "",

--- a/src/main/java/org/wildfly/security/tool/ElytronTool.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronTool.java
@@ -39,12 +39,11 @@ public class ElytronTool {
      */
     public static int ElytronToolExitStatus_OK = 0;
 
-    /**
-     *
-     */
-    public static final String TOOL_JAR = "wildfly-elytron-tool.jar";
-
     private Map<String, Command> commandRegistry = new HashMap<>();
+    /**
+     * Name of the script used to execute the tool.
+     */
+    private String scriptName = null;
 
 
     /**
@@ -67,7 +66,14 @@ public class ElytronTool {
 
         ElytronTool tool = new ElytronTool();
         if (args != null && args.length > 0) {
+            if (args[0].startsWith("{")) {
+                tool.scriptName = args[0].substring(1, args[0].indexOf('}'));
+                args[0] = args[0].substring(args[0].indexOf('}') + 1);
+            }
             Command command = tool.findCommand(args[0]);
+            if (command != null && tool.scriptName != null) {
+                command.setToolCommand(tool.scriptName);
+            }
             String[] newArgs = new String[args.length -1];
             System.arraycopy(args, 1, newArgs, 0, args.length -1);
             if (command != null && newArgs.length > 0) {
@@ -109,6 +115,9 @@ public class ElytronTool {
         System.out.print(ElytronToolMessages.msg.missingArgumentsHelp());
         System.out.println();
         for (Command c: commandRegistry.values()) {
+            if (scriptName != null) {
+                c.setToolCommand(scriptName);
+            }
             c.help();
             System.out.println();
         }

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -45,8 +45,8 @@ public interface ElytronToolMessages extends BasicLogger {
     @Message(id = NONE, value = "Input data not confirmed. Exiting.")
     String inputDataNotConfirmed();
 
-    @Message(id = NONE, value = "java -jar %s %s")
-    String cmdHelp(String jarFile, String commandName);
+    @Message(id = NONE, value = "%s %s")
+    String cmdHelp(String toolCommand, String commandName);
 
     @Message(id = NONE, value = "Exception encountered executing the command:")
     String commandExecuteException();

--- a/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -125,7 +125,7 @@ class MaskCommand extends Command {
     public void help() {
         HelpFormatter help = new HelpFormatter();
         help.setWidth(WIDTH);
-        help.printHelp(ElytronToolMessages.msg.cmdHelp(ElytronTool.TOOL_JAR, MASK_COMMAND),
+        help.printHelp(ElytronToolMessages.msg.cmdHelp(getToolCommand(), MASK_COMMAND),
                 ElytronToolMessages.msg.cmdMaskHelpHeader(),
                 options,
                 "",

--- a/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -221,7 +221,7 @@ public class VaultCommand extends Command {
     public void help() {
         HelpFormatter help = new HelpFormatter();
         help.setWidth(WIDTH);
-        help.printHelp(ElytronToolMessages.msg.cmdHelp(ElytronTool.TOOL_JAR, VAULT_COMMAND),
+        help.printHelp(ElytronToolMessages.msg.cmdHelp(getToolCommand(), VAULT_COMMAND),
                 ElytronToolMessages.msg.cmdVaultHelpHeader(),
                 options,
                 "",


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1228
JBEAP: https://issues.jboss.org/browse/JBEAP-11376