### PR TITLE
[ELY-1165] credential-store command "add" option doesn't contain entry-type in summary CLI command

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -234,17 +234,29 @@ class CredentialStoreCommand extends Command {
             }
             credentialStore.store(alias, createCredential(secret, entryType));
             credentialStore.flush();
-            System.out.println(ElytronToolMessages.msg.aliasStored(alias));
+            if (entryType != null) {
+                System.out.println(ElytronToolMessages.msg.aliasStored(alias, entryType));
+            } else {
+                System.out.println(ElytronToolMessages.msg.aliasStored(alias));
+            }
             setStatus(ElytronTool.ElytronToolExitStatus_OK);
         } else if (cmdLine.hasOption(REMOVE_ALIAS_PARAM)) {
             String alias = cmdLine.getOptionValue(REMOVE_ALIAS_PARAM);
             if (credentialStore.exists(alias, entryTypeToCredential(entryType))) {
                 credentialStore.remove(alias, entryTypeToCredential(entryType));
                 credentialStore.flush();
-                System.out.println(ElytronToolMessages.msg.aliasRemoved(alias));
+                if (entryType != null) {
+                    System.out.println(ElytronToolMessages.msg.aliasRemoved(alias, entryType));
+                } else {
+                    System.out.println(ElytronToolMessages.msg.aliasRemoved(alias));
+                }
                 setStatus(ElytronTool.ElytronToolExitStatus_OK);
             } else {
-                System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias));
+                if (entryType != null) {
+                    System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias, entryType));
+                } else {
+                    System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias));
+                }
                 setStatus(ALIAS_NOT_FOUND);
             }
 
@@ -255,7 +267,11 @@ class CredentialStoreCommand extends Command {
                 System.out.println(ElytronToolMessages.msg.aliasExists(alias));
             } else {
                 setStatus(ALIAS_NOT_FOUND);
-                System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias));
+                if (entryType != null) {
+                    System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias, entryType));
+                } else {
+                    System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias));
+                }
             }
         } else if (cmdLine.hasOption(ALIASES_PARAM)) {
             Set<String> aliases = credentialStore.getAliases();
@@ -294,6 +310,9 @@ class CredentialStoreCommand extends Command {
                 }
                 com.append("/subsystem=elytron/credential-store=test:add-alias(alias=");
                 com.append(cmdLine.getOptionValue(ADD_ALIAS_PARAM));
+                if (entryType != null) {
+                    com.append(",entry-type=\"").append(entryType).append("\"");
+                }
                 com.append(",secret-value=\"");
                 com.append(secret);
                 com.append("\")");

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -123,11 +123,20 @@ public interface ElytronToolMessages extends BasicLogger {
     @Message(id = NONE, value = "Alias \"%s\" does not exist")
     String aliasDoesNotExist(String alias);
 
+    @Message(id = NONE, value = "Alias \"%s\" of type \"%s\"does not exist")
+    String aliasDoesNotExist(String alias, String type);
+
     @Message(id = NONE, value = "Alias \"%s\" has been successfully stored")
     String aliasStored(String alias);
 
+    @Message(id = NONE, value = "Alias \"%s\" of type \"%s\" has been successfully stored")
+    String aliasStored(String alias, String type);
+
     @Message(id = NONE, value = "Alias \"%s\" has been successfully removed")
     String aliasRemoved(String alias);
+
+    @Message(id = NONE, value = "Alias \"%s\" of type \"%s\" has been successfully removed")
+    String aliasRemoved(String alias, String type);
 
     @Message(id = NONE, value = "Credential store command summary:%n--------------------------------------%n%s")
     String commandSummary(String command);


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-10972
https://issues.jboss.org/browse/ELY-1165