### PR TITLE
[ELY-1303] WildFly Elytron Tool, Vault command should support set security provider to convert vaults to custom credential store implementation.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -20,16 +20,9 @@ package org.wildfly.security.tool;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.Security;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -348,45 +341,6 @@ class CredentialStoreCommand extends Command {
         } else {
             throw ElytronToolMessages.msg.unknownEntryType(entryType);
         }
-    }
-
-    private Supplier<Provider[]> getProvidersSupplier(final String providersList) {
-        return () -> {
-            if (providersList != null && !providersList.isEmpty()) {
-                final String[] providerNames = providersList.split(",");
-                List<Provider> providers = new ArrayList<>(providerNames.length);
-                for(String p: providerNames) {
-                    Provider provider = Security.getProvider(p.trim());
-                    if (provider != null) {
-                        providers.add(provider);
-                    }
-                }
-                ServiceLoader<Provider> providerLoader = ServiceLoader.load(Provider.class);
-                for (Provider provider : providerLoader) {
-                    for (String p : providerNames) {
-                        if (provider.getName().equals(p)) {
-                            providers.add(provider);
-                            break;
-                        }
-                    }
-                }
-                if (providers.isEmpty()) {
-                    throw ElytronToolMessages.msg.unknownProvider(providersList);
-                }
-                return providers.toArray(new Provider[providers.size()]);
-            } else {
-                // when no provider list is specified, load all Providers from service loader except WildFlyElytron Provider
-                ServiceLoader<Provider> providerLoader = ServiceLoader.load(Provider.class);
-                Iterator<Provider> providerIterator = providerLoader.iterator();
-                List<Provider> providers = new ArrayList<>();
-                while (providerIterator.hasNext()) {
-                    Provider provider = providerIterator.next();
-                    if (provider.getName().equals("WildFlyElytron")) continue;
-                    providers.add(provider);
-                }
-                return providers.toArray(new Provider[providers.size()]);
-            }
-        };
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -182,7 +182,8 @@ public interface ElytronToolMessages extends BasicLogger {
     IllegalArgumentException invalidParameterMustBeIntBetween(String parameter, int min, int max);
 
     // vault command
-    @Message(id = NONE, value = "\"vault\" command is used convert PicketBox Security Vault to credential store using default implementation (KeyStoreCredentialStore).")
+    @Message(id = NONE, value = "\"vault\" command is used convert PicketBox Security Vault to credential store using default implementation (KeyStoreCredentialStore)" +
+                                " or custom implementation set with the \"type\" option.")
     String cmdVaultHelpHeader();
 
     @Message(id = NONE, value = "Vault keystore URL (defaults to \"vault.keystore\")")
@@ -224,16 +225,20 @@ public interface ElytronToolMessages extends BasicLogger {
     String cliCommandToNewCredentialStore();
 
     @Message(id = NONE, value = "Bulk conversion with options listed in description file. All options have no default value and should be set in the file.%n" +
-                                "All options are required with two exceptions:%n" +
-                                " - \"properties\" option%n" +
+                                "All options are required with the exceptions:%n" +
+                                " - \"properties\" option%n - \"type\" option (defaults to \"KeyStoreCredentialStore\")%n - \"credential-store-provider\" option%n - \"other-providers\" option%n" +
                                 " - \"salt\" and \"iteration\" options can be omitted when plain-text password is used%n" +
                                 "Each set of options must start with the \"keystore\" option in the following format:%n " +
                                 "keystore:<value>%nkeystore-password:<value>%nenc-dir:<value>%nsalt:<value>%niteration:<value>%nlocation:<value>%n" +
-                                "alias:<value>%nproperties:<parameter1>=<value1>; ... ;<parameterN>=<valueN>")
+                                "alias:<value>%nproperties:<parameter1>=<value1>; ... ;<parameterN>=<valueN>%ntype:<value>%n" +
+                                "credential-store-provider:<value>%nother-providers:<value>")
     String cliCommandBulkVaultCredentialStoreConversion();
 
     @Message(id = NONE, value = "Print summary of conversion")
     String cmdLineVaultPrintSummary();
+
+    @Message(id = NONE, value = "Converted credential store type (defaults to \"KeyStoreCredentialStore\")")
+    String cmdLineVaultCSTypeDesc();
 
     @Message(id = NONE, value = "Location of credential store storage file (defaults to \"converted-vault.cr-store\" in vault encryption directory)")
     String cmdLineVaultCSLocationDesc();


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1303
JBEAP: https://issues.jboss.org/browse/JBEAP-12219

Added new options to "vault" command which are similar to "credential-store" command:
--type
--credential-store-provider
--other-providers