### PR TITLE
[ELY-1035] CS tool, Error msg with mutually exclusive parameters must contain "really" used option names.

### DIFF
--- a/src/main/java/org/wildfly/security/tool/ElytronTool.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronTool.java
@@ -17,6 +17,8 @@
  */
 package org.wildfly.security.tool;
 
+import org.apache.commons.cli.AlreadySelectedException;
+import org.apache.commons.cli.Option;
 import org.wildfly.security.WildFlyElytronProvider;
 
 import java.security.Security;
@@ -81,6 +83,10 @@ public class ElytronTool {
                     command.execute(newArgs);
                     System.exit(command.getStatus());
                 } catch (Exception e) {
+                    if (e instanceof AlreadySelectedException) {
+                        Option option = ((AlreadySelectedException) e).getOption();
+                        System.err.println(ElytronToolMessages.msg.longOptionDescription(option.getOpt(), option.getLongOpt()));
+                    }
                     if (command.isEnableDebug()) {
                         System.err.println(ElytronToolMessages.msg.commandExecuteException());
                         e.printStackTrace(System.err);

--- a/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -327,4 +327,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = 27, value = "Wrong masked password format. Expected format is \"MASK-<encoded payload>;<salt>;<iteration>\"")
     IllegalArgumentException wrongMaskedPasswordFormat();
+
+    @Message(id = NONE, value = "In the message below, option '%s' refers to long option '%s'.")
+    String longOptionDescription(String option, String longOption);
 }


### PR DESCRIPTION
wildfly-elytron-tool: https://issues.jboss.org/browse/ELY-1035
